### PR TITLE
update Makefile to automate versoin bump

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,14 @@
 run:
 	poetry run python LuokeCollection/index.py
 
-test:
-	echo "no test yet"
-
 black:
 	poetry run black ./LuokeCollection
 
+# If the first argument is "version"
+ifeq (version,$(firstword $(MAKECMDGOALS)))
+  RUN_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+  $(eval $(RUN_ARGS):;@:)
+endif
 
+version:
+	poetry version $(RUN_ARGS)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "luokecollection"
-version = "0.1.0"
+version = "0.2.0"
 description = ""
 authors = ["Ruoqi Huang <huangruoqi374@gmail.com>"]
 


### PR DESCRIPTION
Reviewer: @huangruoqi @kennygchen 

Changes:
* Update Makefile to automate version bump
* Version: 0.1.0 -> 0.2.0

Testings:
`make version minor` : Version: 0.1.0 -> 0.2.0
`make version major` : Version: 0.1.0 -> 1.0.0
`make version patch` : Version: 0.1.0 -> 0.1.1
